### PR TITLE
Add support for getter-only non-public properties.

### DIFF
--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/CodeRefactoringProvider.cs
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/CodeRefactoringProvider.cs
@@ -16,7 +16,7 @@ namespace CreateConstructorRefactoring
     [ExportCodeRefactoringProvider( LanguageNames.CSharp, Name = nameof( CreateConstructorRefactoringCodeRefactoringProvider ) ), Shared]
     internal class CreateConstructorRefactoringCodeRefactoringProvider : CodeRefactoringProvider
     {
-        private DIPropertyVisitor propertyVisitor = new DIPropertyVisitor();
+        private DIPropertyWalker propertyWalker = new DIPropertyWalker();
 
         private bool CandidateField( FieldDeclarationSyntax fieldDecl )
         {
@@ -26,7 +26,7 @@ namespace CreateConstructorRefactoring
 
         private bool CandidateProperty( PropertyDeclarationSyntax propertyDecl )
         {
-            return propertyDecl != null && propertyVisitor.IsCandidate( propertyDecl );
+            return propertyDecl != null && propertyWalker.IsCandidate( propertyDecl );
         }
 
         private bool IsInjectableType( TypeSyntax type, SemanticModel model )

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/CreateConstructorRefactoring.csproj
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/CreateConstructorRefactoring.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CodeRefactoringProvider.cs" />
+    <Compile Include="DIPropertyVisitor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/CreateConstructorRefactoring.csproj
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/CreateConstructorRefactoring.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CodeRefactoringProvider.cs" />
-    <Compile Include="DIPropertyVisitor.cs" />
+    <Compile Include="DIProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/DIProperty.cs
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/DIProperty.cs
@@ -8,28 +8,18 @@ using System.Threading.Tasks;
 
 namespace CreateConstructorRefactoring
 {
-    internal class DIPropertyVisitor
+    internal class DIPropertyWalker
     {
-        private class PropertyVisitor : CSharpSyntaxVisitor
+        private class PropertyWalker : CSharpSyntaxWalker
         {
             private bool isValid;
 
             public override void VisitPropertyDeclaration( PropertyDeclarationSyntax node )
             {
-                //TODO: Why do I need to do this? 
-                VisitAccessorList( node.AccessorList );
+                base.VisitPropertyDeclaration(node);
                 if( node.Initializer != null || node.Modifiers.Any( m => m.Kind() == SyntaxKind.PublicKeyword || m.Kind() == SyntaxKind.StaticKeyword ) )
                 {
                     isValid = false;
-                }
-            }
-
-            public override void VisitAccessorList( AccessorListSyntax node )
-            {
-                //TODO: Why do I need to do this? 
-                foreach( var accessorDeclarationSyntax in node.Accessors )
-                {
-                    VisitAccessorDeclaration(accessorDeclarationSyntax);
                 }
             }
 
@@ -51,7 +41,7 @@ namespace CreateConstructorRefactoring
 
         public bool IsCandidate( PropertyDeclarationSyntax property )
         {
-            var propertyVisitor = new PropertyVisitor();
+            var propertyVisitor = new PropertyWalker();
             return propertyVisitor.IsCandidate( property );
         }
     }

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/DIPropertyVisitor.cs
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/DIPropertyVisitor.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CreateConstructorRefactoring
+{
+    internal class DIPropertyVisitor
+    {
+        private class PropertyVisitor : CSharpSyntaxVisitor
+        {
+            private bool isValid;
+
+            public override void VisitPropertyDeclaration( PropertyDeclarationSyntax node )
+            {
+                //TODO: Why do I need to do this? 
+                VisitAccessorList( node.AccessorList );
+                if( node.Initializer != null || node.Modifiers.Any( m => m.Kind() == SyntaxKind.PublicKeyword || m.Kind() == SyntaxKind.StaticKeyword ) )
+                {
+                    isValid = false;
+                }
+            }
+
+            public override void VisitAccessorList( AccessorListSyntax node )
+            {
+                //TODO: Why do I need to do this? 
+                foreach( var accessorDeclarationSyntax in node.Accessors )
+                {
+                    VisitAccessorDeclaration(accessorDeclarationSyntax);
+                }
+            }
+
+            public override void VisitAccessorDeclaration( AccessorDeclarationSyntax node )
+            {
+                if( !( node.Kind() == SyntaxKind.GetAccessorDeclaration && node.Body == null ) )
+                {
+                    isValid = false;
+                }
+            }
+
+            public bool IsCandidate( PropertyDeclarationSyntax node )
+            {
+                isValid = true;
+                VisitPropertyDeclaration( node );
+                return isValid;
+            }
+        }
+
+        public bool IsCandidate( PropertyDeclarationSyntax property )
+        {
+            var propertyVisitor = new PropertyVisitor();
+            return propertyVisitor.IsCandidate( property );
+        }
+    }
+}


### PR DESCRIPTION
Getter only properties, which are not initalized, can also store dependencies. 
I added support for generating a DI-constructor using these properties to.

Example:

``` c#
class Dummy
{
    private IDummy Dummy { get; }
} 
```

You can also generate a constructor initailizing the Dummy property.

``` c#
class Dummy
{
    private IDummy Dummy { get; }

    public Dummy(IDummy Dummy)
    {
        this.Dummy = Dummy;
    }
} 
```
