### PR TITLE
Extension migration to Visual Studio 2017

### DIFF
--- a/CreateConstructorRefactoring/CreateConstructorRefactoring.Vsix/CreateConstructorRefactoring.Vsix.csproj
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring.Vsix/CreateConstructorRefactoring.Vsix.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -12,6 +13,7 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{6D6E8705-ABE4-45CD-BFFA-03A0D3CAF7E2}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <VsixType>v3</VsixType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CreateConstructorRefactoring.Vsix</RootNamespace>
     <AssemblyName>CreateConstructorRefactoring.Vsix</AssemblyName>

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring.Vsix/source.extension.vsixmanifest
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring.Vsix/source.extension.vsixmanifest
@@ -6,7 +6,9 @@
     <Description xml:space="preserve">This is a sample code refactoring extension for the .NET Compiler Platform ("Roslyn").</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -14,4 +16,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="CreateConstructorRefactoring" Path="|CreateConstructorRefactoring|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/CodeRefactoringProvider.cs
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/CodeRefactoringProvider.cs
@@ -1,31 +1,30 @@
-using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CreateConstructorRefactoring
 {
-    [ExportCodeRefactoringProvider( LanguageNames.CSharp, Name = nameof( CreateConstructorRefactoringCodeRefactoringProvider ) ), Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(CreateConstructorRefactoringCodeRefactoringProvider)), Shared]
     internal class CreateConstructorRefactoringCodeRefactoringProvider : CodeRefactoringProvider
     {
-        private bool CandidateField( FieldDeclarationSyntax fieldDecl )
+        private bool CandidateField(FieldDeclarationSyntax fieldDecl)
         {
-            return !(fieldDecl == null || fieldDecl.Modifiers.ToString().Contains( SyntaxFactory.Token( SyntaxKind.PublicKeyword ).ToString() ) ||
-                fieldDecl.Modifiers.ToString().Contains( SyntaxFactory.Token( SyntaxKind.StaticKeyword ).ToString() ) || !fieldDecl.Modifiers.ToString().Contains( SyntaxFactory.Token( SyntaxKind.ReadOnlyKeyword ).ToString() ));
+            return !(fieldDecl == null || fieldDecl.Modifiers.ToString().Contains(SyntaxFactory.Token(SyntaxKind.PublicKeyword).ToString())
+                || fieldDecl.Modifiers.ToString().Contains(SyntaxFactory.Token(SyntaxKind.StaticKeyword).ToString())
+                || !fieldDecl.Modifiers.ToString().Contains(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword).ToString()));
         }
 
-        private bool IsInjectableType( FieldDeclarationSyntax fieldDecl, SemanticModel model )
+        private bool IsInjectableType(FieldDeclarationSyntax fieldDecl, SemanticModel model)
         {
-            var symbolInfo = model.GetSymbolInfo( fieldDecl.Declaration.Type );
-            if( symbolInfo.Symbol == null )
+            var symbolInfo = model.GetSymbolInfo(fieldDecl.Declaration.Type);
+            if (symbolInfo.Symbol == null)
             {
                 return false;
             }
@@ -33,103 +32,102 @@ namespace CreateConstructorRefactoring
             return (typeSymbol.IsAbstract && typeSymbol.TypeKind == TypeKind.Class) || typeSymbol.TypeKind == TypeKind.Interface;
         }
 
-        private IMethodSymbol GetBaseCtor( ClassDeclarationSyntax classDecl, SemanticModel model )
+        private IMethodSymbol GetBaseCtor(ClassDeclarationSyntax classDecl, SemanticModel model)
         {
-            var symbolInfo = model.GetDeclaredSymbol( classDecl );
-            if( symbolInfo == null )
+            var symbolInfo = model.GetDeclaredSymbol(classDecl);
+            if (symbolInfo == null)
             {
                 return null;
             }
-            if( symbolInfo.BaseType == null || symbolInfo.BaseType.Name == "System.Object" )
+            if (symbolInfo.BaseType == null || symbolInfo.BaseType.Name == "System.Object")
             {
                 return null;
             }
-            var baseCtors = symbolInfo.BaseType.GetMembers().Where( m => m.Kind == SymbolKind.Method ).Cast<IMethodSymbol>().Where( m => m.MethodKind == MethodKind.Constructor );
-            if( baseCtors.Any( c => c.Parameters.Length == 0 ) )
+            var baseCtors = symbolInfo.BaseType.GetMembers().Where(m => m.Kind == SymbolKind.Method).Cast<IMethodSymbol>().Where(m => m.MethodKind == MethodKind.Constructor);
+            if (baseCtors.Any(c => c.Parameters.Length == 0))
             {
                 return null;
             }
-            return baseCtors.OrderByDescending( c => c.Parameters.Length ).First();
+            return baseCtors.OrderByDescending(c => c.Parameters.Length).First();
         }
 
-        public sealed override async Task ComputeRefactoringsAsync( CodeRefactoringContext context )
+        public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
-            var root = await context.Document.GetSyntaxRootAsync( context.CancellationToken ).ConfigureAwait( false );
-            var node = root.FindNode( context.Span );
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var node = root.FindNode(context.Span);
             var model = await context.Document.GetSemanticModelAsync();
             var fieldDecl = node as FieldDeclarationSyntax;
-            if( !CandidateField( fieldDecl ) || !IsInjectableType( fieldDecl, model ) )
+            if (!CandidateField(fieldDecl) || !IsInjectableType(fieldDecl, model))
             {
                 return;
             }
 
             // For any type declaration node, create a code action to reverse the identifier text.
-            var action = CodeAction.Create( "Create constructor for dependency injection", c => CreateCtor( context, context.Document, model, fieldDecl, c ) );
+            var action = CodeAction.Create("Create constructor for dependency injection", c => CreateCtor(context, context.Document, model, fieldDecl, c));
 
             // Register this code action.
-            context.RegisterRefactoring( action );
+            context.RegisterRefactoring(action);
         }
 
-        private async Task<Document> CreateCtor( CodeRefactoringContext context, Document document, SemanticModel model, FieldDeclarationSyntax fieldDecl, CancellationToken cancellationToken )
+        private async Task<Document> CreateCtor(CodeRefactoringContext context, Document document, SemanticModel model, FieldDeclarationSyntax fieldDecl, CancellationToken cancellationToken)
         {
             var originalType = fieldDecl.Parent as ClassDeclarationSyntax;
             var fields = originalType.DescendantNodes().OfType<FieldDeclarationSyntax>();
-            var candidateFields = fields.Where( f => CandidateField( f ) && IsInjectableType( f, model ) );
+            var candidateFields = fields.Where(f => CandidateField(f) && IsInjectableType(f, model));
             var parameterTokens = new List<SyntaxNodeOrToken>();
             var statements = new List<StatementSyntax>();
-            foreach( var field in candidateFields )
+            foreach (var field in candidateFields)
             {
-                parameterTokens.Add( SyntaxFactory.Parameter( new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), field.Declaration.Type, field.Declaration.Variables[0].Identifier, null ) ); // todo: handle fielddeclarations with multiple variables
-                parameterTokens.Add( SyntaxFactory.Token( SyntaxKind.CommaToken ) );
-                statements.Add( SyntaxFactory.ExpressionStatement(
+                parameterTokens.Add(SyntaxFactory.Parameter(new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), field.Declaration.Type, field.Declaration.Variables[0].Identifier, null)); // todo: handle fielddeclarations with multiple variables
+                parameterTokens.Add(SyntaxFactory.Token(SyntaxKind.CommaToken));
+                statements.Add(SyntaxFactory.ExpressionStatement(
                                         SyntaxFactory.AssignmentExpression(
                                                 SyntaxKind.SimpleAssignmentExpression,
-                                                SyntaxFactory.MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), SyntaxFactory.IdentifierName( field.Declaration.Variables[0].Identifier ) ),
-                                                SyntaxFactory.IdentifierName( field.Declaration.Variables[0].Identifier )
-                    ) ) );
+                                                SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), SyntaxFactory.IdentifierName(field.Declaration.Variables[0].Identifier)),
+                                                SyntaxFactory.IdentifierName(field.Declaration.Variables[0].Identifier)
+                    )));
             }
 
-            var ctor = SyntaxFactory.ConstructorDeclaration( SyntaxFactory.Identifier( originalType.Identifier.ToString() ) )
-                                  .WithModifiers( SyntaxFactory.TokenList( SyntaxFactory.Token( SyntaxKind.PublicKeyword ) ) );
+            var ctor = SyntaxFactory.ConstructorDeclaration(SyntaxFactory.Identifier(originalType.Identifier.ToString()))
+                                  .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)));
 
-
-            var baseCtor = GetBaseCtor( originalType, model );
-            if( baseCtor != null )
+            var baseCtor = GetBaseCtor(originalType, model);
+            if (baseCtor != null)
             {
-                foreach( var baseParam in baseCtor.Parameters )
+                foreach (var baseParam in baseCtor.Parameters)
                 {
-                    parameterTokens.Add( SyntaxFactory.Parameter( new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), SyntaxFactory.IdentifierName( baseParam.Type.Name.ToString() ), SyntaxFactory.Identifier( baseParam.Name.ToString() ), null ) );
-                    parameterTokens.Add( SyntaxFactory.Token( SyntaxKind.CommaToken ) );
+                    parameterTokens.Add(SyntaxFactory.Parameter(new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), SyntaxFactory.IdentifierName(baseParam.Type.Name), SyntaxFactory.Identifier(baseParam.Name), null));
+                    parameterTokens.Add(SyntaxFactory.Token(SyntaxKind.CommaToken));
                 }
             }
-            parameterTokens.RemoveAt( parameterTokens.Count - 1 );
+            parameterTokens.RemoveAt(parameterTokens.Count - 1);
 
-            ctor = ctor.WithParameterList( SyntaxFactory.ParameterList( SyntaxFactory.SeparatedList<ParameterSyntax>( parameterTokens ) ) );
+            ctor = ctor.WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList<ParameterSyntax>(parameterTokens)));
 
-            if( baseCtor != null )
+            if (baseCtor != null)
             {
                 var baseParameterTokens = new List<SyntaxNodeOrToken>();
-                foreach( var baseParam in baseCtor.Parameters )
+                foreach (var baseParam in baseCtor.Parameters)
                 {
-                    baseParameterTokens.Add( SyntaxFactory.Argument( SyntaxFactory.IdentifierName( baseParam.Name.ToString() ) ) );
-                    baseParameterTokens.Add( SyntaxFactory.Token( SyntaxKind.CommaToken ) );
+                    baseParameterTokens.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(baseParam.Name)));
+                    baseParameterTokens.Add(SyntaxFactory.Token(SyntaxKind.CommaToken));
                 }
-                baseParameterTokens.RemoveAt( baseParameterTokens.Count - 1 );
+                baseParameterTokens.RemoveAt(baseParameterTokens.Count - 1);
 
                 ctor = ctor.WithInitializer(
                         SyntaxFactory.ConstructorInitializer(
                             SyntaxKind.BaseConstructorInitializer,
-                            SyntaxFactory.ArgumentList( SyntaxFactory.SeparatedList<ArgumentSyntax>( baseParameterTokens ) ) ) );
+                            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList<ArgumentSyntax>(baseParameterTokens))));
             }
 
-            ctor = ctor.WithBody( SyntaxFactory.Block( statements ) );
+            ctor = ctor.WithBody(SyntaxFactory.Block(statements));
 
-            var newType = originalType.AddMembers( ctor );
+            var newType = originalType.AddMembers(ctor);
 
-            var oldRoot = await context.Document.GetSyntaxRootAsync( cancellationToken ).ConfigureAwait( false );
-            var newRoot = oldRoot.ReplaceNode( originalType, newType );
+            var oldRoot = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = oldRoot.ReplaceNode(originalType, newType);
 
-            return document.WithSyntaxRoot( newRoot );
+            return document.WithSyntaxRoot(newRoot);
         }
     }
 }

--- a/CreateConstructorRefactoring/CreateConstructorRefactoring/CreateConstructorRefactoring.csproj
+++ b/CreateConstructorRefactoring/CreateConstructorRefactoring/CreateConstructorRefactoring.csproj
@@ -1,14 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{FE695822-222A-4220-8CCB-9FF6525EE449}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <VsixType>v3</VsixType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CreateConstructorRefactoring</RootNamespace>
     <AssemblyName>CreateConstructorRefactoring</AssemblyName>
@@ -90,7 +95,6 @@
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.6\Microsoft.Portable.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DependencyInjectionToolset/DependencyInjectionToolset.csproj
+++ b/DependencyInjectionToolset/DependencyInjectionToolset.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -12,6 +13,7 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{CD8C9885-52E0-4CC3-ABFD-F99D9C0F17E5}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <VsixType>v3</VsixType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DependencyInjectionToolset</RootNamespace>
     <AssemblyName>DependencyInjectionToolset</AssemblyName>

--- a/DependencyInjectionToolset/source.extension.vsixmanifest
+++ b/DependencyInjectionToolset/source.extension.vsixmanifest
@@ -10,9 +10,9 @@
     <Tags>Dependency Injection</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -21,4 +21,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="CreateConstructorRefactoring" Path="|CreateConstructorRefactoring|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="IntroduceFieldRefactoring" Path="|IntroduceFieldRefactoring|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/DependenyInjectionToolset.sln
+++ b/DependenyInjectionToolset.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateConstructorRefactoring", "CreateConstructorRefactoring\CreateConstructorRefactoring\CreateConstructorRefactoring.csproj", "{FE695822-222A-4220-8CCB-9FF6525EE449}"
 EndProject
@@ -42,5 +42,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0C13E22A-8751-48C4-8B9E-CE29C4A7E599}
 	EndGlobalSection
 EndGlobal

--- a/IntroduceFieldRefactoring/IntroduceFieldRefactoring.Vsix/IntroduceFieldRefactoring.Vsix.csproj
+++ b/IntroduceFieldRefactoring/IntroduceFieldRefactoring.Vsix/IntroduceFieldRefactoring.Vsix.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -12,6 +13,7 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{B59ECF5B-8DBD-4300-9197-B922DEEE06E0}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <VsixType>v3</VsixType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IntroduceFieldRefactoring.Vsix</RootNamespace>
     <AssemblyName>IntroduceFieldRefactoring.Vsix</AssemblyName>

--- a/IntroduceFieldRefactoring/IntroduceFieldRefactoring.Vsix/source.extension.vsixmanifest
+++ b/IntroduceFieldRefactoring/IntroduceFieldRefactoring.Vsix/source.extension.vsixmanifest
@@ -6,7 +6,9 @@
     <Description xml:space="preserve">This is a sample code refactoring extension for the .NET Compiler Platform ("Roslyn").</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -14,4 +16,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="IntroduceFieldRefactoring" Path="|IntroduceFieldRefactoring|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/IntroduceFieldRefactoring/IntroduceFieldRefactoring/CodeRefactoringProvider.cs
+++ b/IntroduceFieldRefactoring/IntroduceFieldRefactoring/CodeRefactoringProvider.cs
@@ -1,43 +1,40 @@
-using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Text;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace IntroduceFieldRefactoring
 {
-    [ExportCodeRefactoringProvider( LanguageNames.CSharp, Name = nameof( IntroduceFieldRefactoringCodeRefactoringProvider ) ), Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(IntroduceFieldRefactoringCodeRefactoringProvider)), Shared]
     internal class IntroduceFieldRefactoringCodeRefactoringProvider : CodeRefactoringProvider
     {
-        public sealed override async Task ComputeRefactoringsAsync( CodeRefactoringContext context )
+        public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
-            var root = await context.Document.GetSyntaxRootAsync( context.CancellationToken ).ConfigureAwait( false );
-            var node = root.FindNode( context.Span );
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var node = root.FindNode(context.Span);
 
             ParameterSyntax parameter = null;
-            if(node is ParameterListSyntax pls)
+            if (node is ParameterListSyntax pls)
             {
                 var parameterList = pls;
 
                 parameter = parameterList.Parameters.SingleOrDefault(p => p.Span.Contains(context.Span));
-                if(parameter == null)
+                if (parameter == null)
                 {
                     return;
                 }
             }
-            else if(node is ParameterSyntax ps)
+            else if (node is ParameterSyntax ps)
             {
                 parameter = ps;
             }
-            else if(node is IdentifierNameSyntax ins)
+            else if (node is IdentifierNameSyntax ins)
             {
                 var identifier = ins;
                 parameter = identifier.Parent as ParameterSyntax;
@@ -49,85 +46,85 @@ namespace IntroduceFieldRefactoring
             }
 
             var parameterName = GetParameterName(parameter);
-            if(string.IsNullOrEmpty(parameterName) || !(parameter.Parent.Parent is ConstructorDeclarationSyntax))
+            if (string.IsNullOrEmpty(parameterName) || !(parameter.Parent.Parent is ConstructorDeclarationSyntax))
             {
                 return;
             }
 
-            if(!VariableExists(root, "_" + parameterName))
+            if (!VariableExists(root, "_" + parameterName))
             {
                 var action = CodeAction.Create("Introduce and initialize field '_" + parameterName + "'", ct => CreateFieldAsync(context, parameter, parameterName, ct, true));
                 context.RegisterRefactoring(action);
             }
 
-            if(!VariableExists(root, parameterName))
+            if (!VariableExists(root, parameterName))
             {
                 var action2 = CodeAction.Create("Introduce and initialize field 'this." + parameterName + "'", ct => CreateFieldAsync(context, parameter, parameterName, ct));
                 context.RegisterRefactoring(action2);
             }
         }
 
-        private async Task<Document> CreateFieldAsync( CodeRefactoringContext context, ParameterSyntax parameter,
-            string paramName, CancellationToken cancellationToken, bool useUnderscore = false )
+        private async Task<Document> CreateFieldAsync(CodeRefactoringContext context, ParameterSyntax parameter,
+            string paramName, CancellationToken cancellationToken, bool useUnderscore = false)
         {
             ExpressionSyntax assignment = null;
-            if( useUnderscore )
+            if (useUnderscore)
             {
                 assignment = SyntaxFactory.AssignmentExpression(
                          SyntaxKind.SimpleAssignmentExpression,
-                         SyntaxFactory.IdentifierName( "_" + paramName ),
-                         SyntaxFactory.IdentifierName( paramName ) );
+                         SyntaxFactory.IdentifierName("_" + paramName),
+                         SyntaxFactory.IdentifierName(paramName));
             }
             else
             {
                 assignment = SyntaxFactory.AssignmentExpression(
                          SyntaxKind.SimpleAssignmentExpression,
-                         SyntaxFactory.MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), SyntaxFactory.IdentifierName( paramName ) ),
-                         SyntaxFactory.IdentifierName( paramName ) );
+                         SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), SyntaxFactory.IdentifierName(paramName)),
+                         SyntaxFactory.IdentifierName(paramName));
             }
             var oldConstructor = parameter.Ancestors().OfType<ConstructorDeclarationSyntax>().First();
-            var newConstructor = oldConstructor.WithBody( oldConstructor.Body.AddStatements(
-                 SyntaxFactory.ExpressionStatement( assignment ) ) );
+            var newConstructor = oldConstructor.WithBody(oldConstructor.Body.AddStatements(
+                 SyntaxFactory.ExpressionStatement(assignment)));
 
             var oldClass = parameter.FirstAncestorOrSelf<ClassDeclarationSyntax>();
-            var oldClassWithNewCtor = oldClass.ReplaceNode( oldConstructor, newConstructor );
+            var oldClassWithNewCtor = oldClass.ReplaceNode(oldConstructor, newConstructor);
 
-            var fieldDeclaration = CreateFieldDeclaration( GetParameterType( parameter ), paramName, useUnderscore );
+            var fieldDeclaration = CreateFieldDeclaration(GetParameterType(parameter), paramName, useUnderscore);
             var newClass = oldClassWithNewCtor
-                .WithMembers( oldClassWithNewCtor.Members.Insert( 0, fieldDeclaration ) )
-                .WithAdditionalAnnotations( Formatter.Annotation );
+                .WithMembers(oldClassWithNewCtor.Members.Insert(0, fieldDeclaration))
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
-            var oldRoot = await context.Document.GetSyntaxRootAsync( cancellationToken ).ConfigureAwait( false );
-            var newRoot = oldRoot.ReplaceNode( oldClass, newClass );
+            var oldRoot = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = oldRoot.ReplaceNode(oldClass, newClass);
 
-            return context.Document.WithSyntaxRoot( newRoot );
+            return context.Document.WithSyntaxRoot(newRoot);
         }
 
-        public static bool VariableExists( SyntaxNode root, params string[] variableNames )
+        public static bool VariableExists(SyntaxNode root, params string[] variableNames)
         {
             return root
                 .DescendantNodes()
                 .OfType<VariableDeclarationSyntax>()
-                .SelectMany( ps => ps.DescendantTokens().Where( t => t.IsKind( SyntaxKind.IdentifierToken ) && variableNames.Contains( t.ValueText ) ) )
+                .SelectMany(ps => ps.DescendantTokens().Where(t => t.IsKind(SyntaxKind.IdentifierToken) && variableNames.Contains(t.ValueText)))
                 .Any();
         }
 
-        public static string GetParameterType( ParameterSyntax parameter )
+        public static string GetParameterType(ParameterSyntax parameter)
         {
-            return parameter.DescendantNodes().First( node => node is TypeSyntax ).GetFirstToken().ValueText;
+            return parameter.DescendantNodes().First(node => node is TypeSyntax).GetFirstToken().ValueText;
         }
 
-        private static string GetParameterName( ParameterSyntax parameter )
+        private static string GetParameterName(ParameterSyntax parameter)
         {
-            return parameter.DescendantTokens().Where( t => t.IsKind( SyntaxKind.IdentifierToken ) ).Last().ValueText;
+            return parameter.DescendantTokens().Where(t => t.IsKind(SyntaxKind.IdentifierToken)).Last().ValueText;
         }
 
-        private static FieldDeclarationSyntax CreateFieldDeclaration( string type, string name, bool useUnderscore = false )
+        private static FieldDeclarationSyntax CreateFieldDeclaration(string type, string name, bool useUnderscore = false)
         {
             return SyntaxFactory.FieldDeclaration(
-                SyntaxFactory.VariableDeclaration( SyntaxFactory.IdentifierName( type ) )
-                .WithVariables( SyntaxFactory.SingletonSeparatedList( SyntaxFactory.VariableDeclarator( SyntaxFactory.Identifier( useUnderscore ? "_" + name : name ) ) ) ) )
-                .WithModifiers( SyntaxFactory.TokenList( SyntaxFactory.Token( SyntaxKind.PrivateKeyword ), SyntaxFactory.Token( SyntaxKind.ReadOnlyKeyword ) ) );
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(type))
+                .WithVariables(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(useUnderscore ? "_" + name : name)))))
+                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)));
         }
     }
 }

--- a/IntroduceFieldRefactoring/IntroduceFieldRefactoring/CodeRefactoringProvider.cs
+++ b/IntroduceFieldRefactoring/IntroduceFieldRefactoring/CodeRefactoringProvider.cs
@@ -22,10 +22,10 @@ namespace IntroduceFieldRefactoring
             var root = await context.Document.GetSyntaxRootAsync( context.CancellationToken ).ConfigureAwait( false );
             var node = root.FindNode( context.Span );
 
-            ParameterSyntax parameter;
-            if(node is ParameterListSyntax)
+            ParameterSyntax parameter = null;
+            if(node is ParameterListSyntax pls)
             {
-                var parameterList = (ParameterListSyntax)node;
+                var parameterList = pls;
 
                 parameter = parameterList.Parameters.SingleOrDefault(p => p.Span.Contains(context.Span));
                 if(parameter == null)
@@ -33,16 +33,17 @@ namespace IntroduceFieldRefactoring
                     return;
                 }
             }
-            else if(node is ParameterSyntax)
+            else if(node is ParameterSyntax ps)
             {
-                parameter = (ParameterSyntax)node;
+                parameter = ps;
             }
-            else if(node is IdentifierNameSyntax)
+            else if(node is IdentifierNameSyntax ins)
             {
-                var indentifier = (IdentifierNameSyntax)node;
-                parameter = (ParameterSyntax)indentifier.Parent;
+                var identifier = ins;
+                parameter = identifier.Parent as ParameterSyntax;
             }
-            else
+
+            if (parameter == null)
             {
                 return;
             }

--- a/IntroduceFieldRefactoring/IntroduceFieldRefactoring/IntroduceFieldRefactoring.csproj
+++ b/IntroduceFieldRefactoring/IntroduceFieldRefactoring/IntroduceFieldRefactoring.csproj
@@ -1,14 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{18445C9C-B08C-4A2E-B110-0BAF1F1E5B48}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <VsixType>v3</VsixType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IntroduceFieldRefactoring</RootNamespace>
     <AssemblyName>IntroduceFieldRefactoring</AssemblyName>
@@ -89,8 +94,10 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.6\Microsoft.Portable.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
The project and the extension have been migrated to Visual Studio 2017 with a bug fix on crash.

I have not opened the project with older VS nor installed the extension on older VS instance. Testing required.

Some adjustment to DependencyInjectToolset project settings may be required in order to run in debug mode. See [Update Debug settings for project](https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-migrate-extensibility-projects-to-visual-studio-2017#update-debug-settings-for-project) section and take note on **Start external program** field and **Command line arguments** field. This setting is saved in .csproj.user which is in .gitignore, so it's not in the repo.